### PR TITLE
fix github repo in metadata and links

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -61,7 +61,7 @@ git_url = https://github.com/robrwo/perl-Dist-Zilla-Plugin-Test-MixedScripts
 report_url = https://github.com/robrwo/perl-Dist-Zilla-Plugin-Test-MixedScripts/security/advisories
 
 [GitHub::Meta]
-repo = git://github.com/robrwo/perl-Dist-Zilla-Plugin-Test-MixedScripts.git
+repo = robrwo/perl-Dist-Zilla-Plugin-Test-MixedScripts
 
 [PodWeaver]
 [ReadmeAnyFromPod]


### PR DESCRIPTION
The repo option to [GitHub::Meta] is expected to be the repo slug, not a full URL. But the specified repo is usually ignored, favoring the configured remote URL from git.