### PR TITLE
use C<> formatting for example URLs

### DIFF
--- a/lib/Dist/Zilla/Plugin/Test/MixedScripts.pm
+++ b/lib/Dist/Zilla/Plugin/Test/MixedScripts.pm
@@ -41,7 +41,7 @@ This generates an author L<Test::MixedScripts>.
 This is an extension of L<Dist::Zilla::Plugin::InlineFiles>, providing the file F<xt/author/mixed-unicode-scripts.t> for
 testing against mixed Unicode scripts that are potentially confusing or malicious.
 
-For example, the text for the domain names "E<0x043e>nE<0x0435>.example.com" and "one.example.com" look indistinguishable in many fonts,
+For example, the text for the domain names C<< E<0x043e>nE<0x0435>.example.com >> and C<one.example.com> look indistinguishable in many fonts,
 but the first one has Cyrillic letters.  If your software interacted with a service on the second domain, then someone
 can operate a service on the first domain and attempt to fool developers into using their domain instead.
 


### PR DESCRIPTION
Raw URLs in Pod are generally better formatted using C<>. This also prevents them from being spell checked by Test::Spelling.